### PR TITLE
Hotfix! Added getUserById() and person_id for new-item page!

### DIFF
--- a/src/pages/new-item/new-item.ts
+++ b/src/pages/new-item/new-item.ts
@@ -65,6 +65,7 @@ export class NewItemPage {
       // todo change these after user system is done
       email: value.personEmail,
       person_name: value.personName,
+      person_id: this.user.getCurrentUser().user_id,
       // todo this should not be here
       radius: 2
     });

--- a/src/providers/user-service/user-service.ts
+++ b/src/providers/user-service/user-service.ts
@@ -35,4 +35,14 @@ export class UserService {
   public getUsers(){
     return {userA: this._userA, userB: this._userB};
   }
+
+  public getUserById(id){
+    if(id == 0){
+      return this._userA;
+    }else if(id == 1){
+      return this._userB;
+    }else{
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
Shuqiang needed lender's id to save it on saving borrow requests and I missed it. Fix it now!

New function in `UserService`: `getUserById(id)` returns target user object. we only have user with ids of 0 and 1.

Also check #18 to see all useful info!